### PR TITLE
Fix CardSched: Reset last_ivl to 0 when answer is EASE_AGAIN

### DIFF
--- a/app/src/main/java/com/born2go/lazzybee/algorithms/CardSched.java
+++ b/app/src/main/java/com/born2go/lazzybee/algorithms/CardSched.java
@@ -149,6 +149,8 @@ public class CardSched {
             * We don't re-count 'due', because app will put it back to learnt queue
             * */
             card.setQueue(Card.QUEUE_LNR1);
+            //Reset last-interval to reduce next review
+            card.setLast_ivl(0);
         }
         else {
             card.setQueue(Card.QUEUE_REV2);


### PR DESCRIPTION
So, if for a very long review, user doesn't remember and hit again. Next review will be in few days, not too long as before